### PR TITLE
check for empty bundle_gemfile param

### DIFF
--- a/lib/mina/unicorn/tasks.rb
+++ b/lib/mina/unicorn/tasks.rb
@@ -11,6 +11,7 @@ namespace :unicorn do
   set_default :unicorn_pid,       -> { "#{deploy_to}/#{current_path}/tmp/pids/unicorn.pid"  }
   set_default :unicorn_cmd,       -> { "#{bundle_prefix} unicorn" }
   set_default :unicorn_restart_sleep_time, -> { 2 }
+  set_default :bundle_gemfile,    -> { "#{deploy_to}/#{current_path}/Gemfile" }
 
   desc "Start Unicorn master process"
   task start: :environment do


### PR DESCRIPTION
I have added check for bundle_gemfile param, because it works fine without it, due to popular question at stackoverflow:
http://stackoverflow.com/questions/28459488/unicorn-not-starting-when-using-mina/28561296